### PR TITLE
Fixed a lot of memory leaks and segfault bug.

### DIFF
--- a/src/Filter.cpp
+++ b/src/Filter.cpp
@@ -67,6 +67,7 @@ bool Filter::matches( const char* str,const char* pattern)
                  ovector,              /* output vector for substring information */
                  OVECCOUNT);           /* number of elements in the output vector */
 
+    pcre_free(re);
     return (rc >= 0);
 }
 


### PR DESCRIPTION
Fixed a lot of memory leaks. The memory allocated by the operators "new" and "strdup" was not freed, PCRE expressions were not deleted after compilation. Fixed "segmentation fault" in case of deleting an still used file (fuse creating .fuse_hiddenXXX...X files).